### PR TITLE
Added Error to the response struct

### DIFF
--- a/api.go
+++ b/api.go
@@ -43,6 +43,7 @@ type ValidateResponse struct {
 	City          string      `json:"city"`
 	Zipcode       string      `json:"zipcode"`
 	ProcessedAt   string      `json:"processed_at"`
+	Error         string      `json:"error"`
 }
 
 // IsValid checks if an email is valid


### PR DESCRIPTION
When ZB is out of credit API returns 200 with body `{"error":"Invalid API key or your account ran out of credits"}"`